### PR TITLE
Fix td3.json and td4 json config files

### DIFF
--- a/index/conf/td3.json
+++ b/index/conf/td3.json
@@ -17,18 +17,17 @@
 	"dbg": {
 		"debug": false
 	},
-	"exp": {
-		"solver": {
-			"td3": {
-				"restart": {
-					"wpoint": {
-						"enabled": false,
-						"once": true
-					}
-				},
-				"abort": false,
-				"abort-verify": false
-			}
+	"solver": "td3",
+	"solvers": {
+		"td3": {
+			"restart": {
+				"wpoint": {
+					"enabled": false,
+					"once": true
+				}
+			},
+			"abort": false,
+			"abort-verify": false
 		}
 	},
 	"incremental": {

--- a/index/conf/td4.json
+++ b/index/conf/td4.json
@@ -17,18 +17,17 @@
 	"dbg": {
 		"debug": false
 	},
-	"exp": {
-		"solver": {
-			"td3": {
-				"restart": {
-					"wpoint": {
-						"enabled": true,
-						"once": false
-					}
-				},
-				"abort": false,
-				"abort-verify": false
-			}
+	"solver": "td3",
+	"solvers": {
+		"td3": {
+			"restart": {
+				"wpoint": {
+					"enabled": true,
+					"once": false
+				}
+			},
+			"abort": false,
+			"abort-verify": false
 		}
 	},
 	"incremental": {

--- a/index/defs/performance.yaml
+++ b/index/defs/performance.yaml
@@ -5,5 +5,5 @@ incremental: true
 FromScratch:
 Restart:      --enable incremental.restart.sided.enabled
 Reluctant:    --enable incremental.restart.sided.enabled --enable incremental.reluctant.on
-Abort:        --enable incremental.restart.sided.enabled --enable exp.solver.td3.abort
-Both:         --enable incremental.restart.sided.enabled --enable incremental.reluctant.on --enable exp.solver.td3.abort
+Abort:        --enable incremental.restart.sided.enabled --enable solvers.td3.abort
+Both:         --enable incremental.restart.sided.enabled --enable incremental.reluctant.on --enable solvers.td3.abort

--- a/index/defs/precision.yaml
+++ b/index/defs/precision.yaml
@@ -5,5 +5,5 @@ incremental: true
 FromScratch:
 Incremental:
 RestartGlob: --enable incremental.restart.sided.enabled
-RestartLocs: --enable exp.solver.td3.restart.wpoint.enabled
-RestartBoth: --enable exp.solver.td3.restart.wpoint.enabled --enable incremental.restart.sided.enabled
+RestartLocs: --enable solvers.td3.restart.wpoint.enabled
+RestartBoth: --enable solvers.td3.restart.wpoint.enabled --enable incremental.restart.sided.enabled

--- a/index/defs/restarting.yaml
+++ b/index/defs/restarting.yaml
@@ -3,7 +3,7 @@ compare: true
 incremental: true
 
 FromScratch:
-Incremental: --disable exp.solver.td3.restart.wpoint.enabled
-RestartGlob: --disable exp.solver.td3.restart.wpoint.enabled --enable incremental.restart.sided.enabled
+Incremental: --disable solvers.td3.restart.wpoint.enabled
+RestartGlob: --disable solvers.td3.restart.wpoint.enabled --enable incremental.restart.sided.enabled
 RestartLocs:
 RestartBoth: --enable incremental.restart.sided.enabled

--- a/index/defs/td3and4.yaml
+++ b/index/defs/td3and4.yaml
@@ -3,8 +3,8 @@ compare: true
 incremental: false
 
 TD3:
-TD3-Abort:  --enable exp.solver.td3.abort
-TD3-Verify: --enable exp.solver.td3.abort --enable exp.solver.td3.abort-verify
-TD4:        --enable exp.solver.td3.restart.wpoint.enabled --disable exp.solver.td3.restart.wpoint.once
-TD4-Abort:  --enable exp.solver.td3.restart.wpoint.enabled --disable exp.solver.td3.restart.wpoint.once --enable exp.solver.td3.abort
-TD4-Verify: --enable exp.solver.td3.restart.wpoint.enabled --disable exp.solver.td3.restart.wpoint.once --enable exp.solver.td3.abort --enable exp.solver.td3.abort-verify
+TD3-Abort:  --enable solvers.td3.abort
+TD3-Verify: --enable solvers.td3.abort --enable solvers.td3.abort-verify
+TD4:        --enable solvers.td3.restart.wpoint.enabled --disable solvers.td3.restart.wpoint.once
+TD4-Abort:  --enable solvers.td3.restart.wpoint.enabled --disable solvers.td3.restart.wpoint.once --enable solvers.td3.abort
+TD4-Verify: --enable solvers.td3.restart.wpoint.enabled --disable solvers.td3.restart.wpoint.once --enable solvers.td3.abort --enable solvers.td3.abort-verify

--- a/update_bench_incremental.rb
+++ b/update_bench_incremental.rb
@@ -156,7 +156,7 @@ end
 
 if ARGV[2].nil?
   puts 'You must run command with timout, conf, and at least one benchmark set, e.g.:'
-  puts './update_bench_incremental.rb 60 index/defs/interactive.yaml index/sets/posix.yaml'
+  puts './update_bench_incremental.rb 60 index/defs/incremental.yaml index/sets/posix.yaml'
   exit 1
 end
 


### PR DESCRIPTION
The accepted json-format changed, the option `"exp.solver"` moved to `"solver"`and `"solvers"`. This PR fixes the config files so that  `./update_bench_incremental.rb 60 index/defs/incremental.yaml index/sets/posix.yaml` works again