### PR TITLE
Watts benchmark fixes

### DIFF
--- a/index/traces-relational-watts.txt
+++ b/index/traces-relational-watts.txt
@@ -1,10 +1,7 @@
-dummy: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization top
-mutex-meet-box:  --set ana.activated[+] apron --set ana.path_sens[+] threadflag --sets ana.apron.privatization mutex-meet --sets ana.apron.domain interval
-mutex-meet: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet
-mutex-meet-tid: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
-mutex-meet-tid-nj: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid --disable ana.apron.priv.must-joined
-mutex-meet-tid-cluster12-th:  --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid-cluster12 --enable ana.apron.threshold_widening
-
+box: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet --sets ana.apron.domain interval
+oct: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet
+tid: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid
+cluster12: --set ana.activated[+] apron --set ana.path_sens[+] threadflag --set ana.apron.privatization mutex-meet-tid-cluster12
 
 Group: Watts benchmarks by Kusano, Wang
 

--- a/index/traces-relational-watts.txt
+++ b/index/traces-relational-watts.txt
@@ -193,6 +193,8 @@ pcwd_pci_01_main.c
 watts/pcwd_pci_01/main.c
 -
 
+Group: Watts scalability benchmarks by Kusano, Wang
+
 i8xx_tco_03_thr01
 i8xx_tco_03_thr01_main.c
 watts/i8xx_tco_03_thr01/main.c


### PR DESCRIPTION
This PR changes the name of the configurations for the watts benchmarks and separates the scalability benchmarks to a different group.